### PR TITLE
fix some base64 image cannot show due to angular security check

### DIFF
--- a/projects/angular-image-viewer/src/lib/angular-image-viewer.component.html
+++ b/projects/angular-image-viewer/src/lib/angular-image-viewer.component.html
@@ -1,7 +1,7 @@
 <div [appScreenfull]="fullscreen" class="img-container" [style.height]="styleHeight"
     [style.backgroundColor]="config.containerBackgroundColor" (wheel)="scrollZoom($event)"
     (dragover)="onDragOver($event)">
-    <img [src]="src[index]" [ngStyle]="style" alt="Image not found..." (dragstart)="onDragStart($event)"
+    <img [src]="getSafeImageUrl(src[index])" [ngStyle]="style" alt="Image not found..." (dragstart)="onDragStart($event)"
         (load)="onLoad(src[index])" (error)="imageNotFound(src[index])" (loadstart)="onLoadStart(src[index])" />
     <!-- Div below will be used to hide the 'ghost' image when dragging -->
     <div></div>

--- a/projects/angular-image-viewer/src/lib/angular-image-viewer.component.ts
+++ b/projects/angular-image-viewer/src/lib/angular-image-viewer.component.ts
@@ -222,6 +222,14 @@ export class AngularImageViewerComponent implements OnInit, OnChanges {
     this.updateStyle();
   }
 
+  getSafeImageUrl(image: string) {
+    if (image.startsWith('http')) {
+      return this.sanitizer.bypassSecurityTrustUrl(image);
+    } else {
+      return this.sanitizer.bypassSecurityTrustResourceUrl(image);
+    }
+  }
+
   @HostListener('mouseover')
   onMouseOver() {
     this.hovered = true;


### PR DESCRIPTION
Due to angular security check some base64 image will be replace to `unsafe:data:image...`, then image cannot show anymore because of incorrect src format.

I fix this problem by add `bypassSecurityTrustResourceUrl` and `bypassSecurityTrustUrl` to pass security check. this may cause xss attack, more detail can find in https://angular.io/api/platform-browser/DomSanitizer.